### PR TITLE
Installation script fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
       name='gym_battleship',
       version='0.0.1',
       install_requires=['gym', 'numpy', 'pandas']
+      packages=find_packages()
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import find_packages, setup
 setup(
       name='gym_battleship',
       version='0.0.1',
-      install_requires=['gym', 'numpy', 'pandas']
+      install_requires=['gym', 'numpy', 'pandas'],
       packages=find_packages()
 )


### PR DESCRIPTION
Hi there,

I'm planning on using this environment for some battleship AIs and noticed a bug in the package installation. It won't actually download the package the battleship environment is in. This means the environments can't be found:

```python
import gym
import gym_battleship
env = gym.make('Battleship-v0')
env.reset()
```

yields:
```
Traceback (most recent call last):
  File "/home/niklasz/Desktop/ucla/deep_learning/project/code/src/temp.py", line 2, in <module>
    import gym_battleship
ModuleNotFoundError: No module named 'gym_battleship'
```

This PR ensures the packages are included when running `pip install git+https://github.com/thomashirtz/gym-battleship`.  For reference here are the logs of the old vs. new installation:

* [old_installation.log](https://github.com/thomashirtz/gym-battleship/files/8163860/old_installation.log)
* [new_installation.log](https://github.com/thomashirtz/gym-battleship/files/8163859/new_installation.log)